### PR TITLE
fix: Use explicit generic updater for galaxy.yml in release-please

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: marcstraube
 name: rocky
-version: 1.0.0
+version: 1.0.0 # x-release-please-version
 readme: README.md
 authors:
   - Marc Straube <email@marcstraube.de>

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,9 +18,8 @@
       ],
       "extra-files": [
         {
-          "type": "yaml",
-          "path": "galaxy.yml",
-          "jsonpath": "$.version"
+          "type": "generic",
+          "path": "galaxy.yml"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Switch `extra-files` entry in `release-please-config.json` from `type: yaml` to `type: generic`
- Add `# x-release-please-version` annotation to the version line in `galaxy.yml`

The YAML updater (js-yaml) strips `---` document start markers and comments from galaxy.yml — a known unfixed bug in release-please GenericYaml. The generic updater does line-by-line regex matching on the annotation, preserving all formatting.

## Test plan

- [ ] Verify release-please bot picks up the generic updater config
- [ ] On next release, confirm `galaxy.yml` retains `---` and comments after version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)