### PR TITLE
chore: Exclude auto-generated CHANGELOG from markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,5 @@
+---
+config:
+  extends: .markdownlint.yml
+ignores:
+  - "CHANGELOG.md"


### PR DESCRIPTION
## Summary

- Add `.markdownlint-cli2.yaml` with `ignores: ["CHANGELOG.md"]`
- Release-please generates CHANGELOG with its own formatting that conflicts with markdownlint rules
- Matches the pattern used in the common collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)