### PR TITLE
chore: Exclude CHANGELOG.md from markdownlint and pin Node.js 22 LTS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,9 @@ repos:
     hooks:
       - id: markdownlint
         name: Markdown Lint
+        language_version: '22.22.0'
         args: [--config=.markdownlint.yml]
+        exclude: '^CHANGELOG\.md$'
 
   # =============================================================================
   # GENERAL


### PR DESCRIPTION
## Summary

- Add `exclude: '^CHANGELOG\.md$'` to markdownlint pre-commit hook
- Add `language_version: '22.22.0'` to pin Node.js 22 LTS (fixes Node 25 incompatibility)
- Release-please generates CHANGELOG with formatting that conflicts with markdownlint rules
- Matches common/desktop collection pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)