### PR TITLE
ci: add workflow_dispatch trigger for on-demand runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   # =============================================================================


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to the CI workflow so the full matrix can be run manually from any branch (for example, to verify infrastructure changes before merge). Brings this collection in line with common and desktop, which already expose this trigger.

## Test plan

- [x] `yamllint` passes on `ci.yml`
