### PR TITLE
ci: pin molecule to the last schema-compatible release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install "ansible-core~=2.17.0" \
-                      molecule \
-                      molecule-plugins[podman] \
+                      "molecule==26.6.0" \
+                      "molecule-plugins[podman]==26.7.8" \
                       passlib
 
       - name: Install collection dependencies


### PR DESCRIPTION
## Summary

The unpinned `molecule` install pulled a newer release whose `molecule.yml` schema rejects the `tmpfs` mapping (`... is not of type 'array'`), failing every podman molecule job at config validation. This pins `molecule==26.6.0` and `molecule-plugins[podman]==26.7.8` to match the other collections.

## Test plan

- [x] `yamllint` passes on `ci.yml`
