### PR TITLE
ci: centralize pip dependencies into requirements files and enable caching

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,0 +1,3 @@
+ansible-core
+ansible-lint
+yamllint

--- a/.github/requirements-molecule.txt
+++ b/.github/requirements-molecule.txt
@@ -1,0 +1,3 @@
+molecule==26.6.0
+molecule-plugins[podman]==26.7.8
+passlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,14 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
       - name: Install dependencies
-        run: |
-          pip install ansible-core ansible-lint
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Install collection dependencies
         run: |
@@ -63,12 +64,14 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
-      - name: Install yamllint
-        run: pip install yamllint
+      - name: Install dependencies
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Run yamllint
         run: yamllint -c .yamllint .
@@ -153,16 +156,14 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-molecule.txt
 
       - name: Install dependencies
-        run: |
-          pip install "ansible-core~=2.17.0" \
-                      "molecule==26.6.0" \
-                      "molecule-plugins[podman]==26.7.8" \
-                      passlib
+        run: pip install "ansible-core~=2.17.0" -r .github/requirements-molecule.txt
 
       - name: Install collection dependencies
         run: |
@@ -201,12 +202,14 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
-      - name: Install Ansible
-        run: pip install ansible-core
+      - name: Install dependencies
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Build collection
         run: ansible-galaxy collection build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,14 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
-      - name: Install Ansible
-        run: pip install ansible-core
+      - name: Install dependencies
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Build and publish to Galaxy
         run: |


### PR DESCRIPTION
## Summary

Applies the CI requirements-file + pip-caching convention (design in marcstraube/ansible-collection-common#289) to this collection.

## Changes

- Add `.github/requirements-ci.txt` (unpinned `ansible-core` / `ansible-lint` / `yamllint`) and `.github/requirements-molecule.txt` (the pinned molecule stack — single source of truth for the pins).
- Wire every `setup-python` job (`lint`, `yaml-lint`, `build`, `publish`, `molecule-roles`) to `cache: 'pip'` + `cache-dependency-path`, installing via `pip install -r`. The molecule job keeps its `ansible-core` matrix version (`~=2.17.0`) inline.
- Bump `actions/setup-python` v6 → v7 across all workflows.

The `.github` tree is in `build_ignore`, so the requirements files stay out of the Galaxy tarball.

## Acceptance criteria

- [x] Both requirements files added; molecule pins live only in `requirements-molecule.txt`
- [x] All Python jobs use `pip install -r …` + `cache: 'pip'` + `cache-dependency-path`
- [x] `actions/setup-python` pinned to v7 across all workflows
- [ ] CI green — `lint` / `build` / `ci-gate` run on this PR. `molecule-roles` is gated by `detect-changes` and skipped for `.github`-only changes, so it is verified via a manual `workflow_dispatch` on `main` after merge.

References #13
